### PR TITLE
feat: support generating object IDs for mindmap

### DIFF
--- a/public/assets/scripts/network.js
+++ b/public/assets/scripts/network.js
@@ -145,4 +145,4 @@ function generateCluster(clusterOptions, childNodes, childEdges) {
   return clusterOptions;
 }
 
-var network = await initializeNetwork();
+var res =  initializeNetwork();

--- a/public/assets/scripts/network.js
+++ b/public/assets/scripts/network.js
@@ -127,6 +127,10 @@ async function initializeNetwork() {
     }
   });
 
+  network.on("stabilized", function (obj) {
+    network;
+  });
+
   return network;
 }
 
@@ -141,4 +145,4 @@ function generateCluster(clusterOptions, childNodes, childEdges) {
   return clusterOptions;
 }
 
-initializeNetwork();
+var network = await initializeNetwork();

--- a/public/assets/scripts/sub-network.js
+++ b/public/assets/scripts/sub-network.js
@@ -108,4 +108,4 @@ async function initializeSubnetwork(pageName) {
 }
 
 var pageName = document.getElementsByClassName('post-title').item(0).textContent.split('.')[0]
-var network = await initializeSubnetwork(pageName);
+var res = initializeSubnetwork(pageName);

--- a/public/assets/scripts/sub-network.js
+++ b/public/assets/scripts/sub-network.js
@@ -99,7 +99,13 @@ async function initializeSubnetwork(pageName) {
 
     window.location = new URL('/notes/' + title, window.location.origin)
   });
+
+  network.on("stabilized", function (obj) {
+    network;
+  });
+
+  return network;
 }
 
 var pageName = document.getElementsByClassName('post-title').item(0).textContent.split('.')[0]
-initializeSubnetwork(pageName);
+var network = await initializeSubnetwork(pageName);

--- a/src/main/scala/mindmap/effect/MemoryMindmap.scala
+++ b/src/main/scala/mindmap/effect/MemoryMindmap.scala
@@ -16,7 +16,7 @@ import mindmap.model.graph.NetworkEdge
 
 class MemoryMindmap[F[_]: MonadError[*[_], Throwable]](
   graph: Graph[Entity, DiEdge],
-  network: Network,
+  network: Network
 ) extends MindmapAlgebra[F] {
   def network(): F[Network] = network.pure[F]
 

--- a/src/main/scala/mindmap/effect/MemoryMindmap.scala
+++ b/src/main/scala/mindmap/effect/MemoryMindmap.scala
@@ -16,7 +16,7 @@ import mindmap.model.graph.NetworkEdge
 
 class MemoryMindmap[F[_]: MonadError[*[_], Throwable]](
   graph: Graph[Entity, DiEdge],
-  network: Network
+  network: Network,
 ) extends MindmapAlgebra[F] {
   def network(): F[Network] = network.pure[F]
 
@@ -31,7 +31,8 @@ class MemoryMindmap[F[_]: MonadError[*[_], Throwable]](
     )
     neighborhood = Set(node).union(node.neighbors)
     nodeMap = neighborhood
-      .map(entity => {
+      .map(graphNode => {
+        val entity = graphNode.toOuter
         val networkNode = entity match {
           case note: Note => NetworkNode.noteNode(note.title, note.content)
           case tag: Tag => NetworkNode.tagNode(tag.name)

--- a/src/main/scala/mindmap/effect/MemoryMindmap.scala
+++ b/src/main/scala/mindmap/effect/MemoryMindmap.scala
@@ -13,7 +13,6 @@ import mindmap.model.Tag
 import mindmap.model.graph.Network
 import mindmap.model.graph.NetworkNode
 import mindmap.model.graph.NetworkEdge
-import java.nio.file.NotLinkException
 
 class MemoryMindmap[F[_]: MonadError[*[_], Throwable]](
   graph: Graph[Entity, DiEdge],
@@ -21,32 +20,35 @@ class MemoryMindmap[F[_]: MonadError[*[_], Throwable]](
 ) extends MindmapAlgebra[F] {
   def network(): F[Network] = network.pure[F]
 
+  def find(id: Long): F[Option[NetworkNode]] = {
+    network.find(id).pure[F]
+  }
+
   def subnetwork(entity: Entity): F[Network] = for {
     node <- MonadError[F, Throwable].fromOption(
       graph.find(entity),
       new Exception("No entity")
     )
     neighborhood = Set(node).union(node.neighbors)
-    idxByNode = neighborhood
-      .map(_.toOuter)
-      .zipWithIndex
+    nodeMap = neighborhood
+      .map(entity => {
+        val networkNode = entity match {
+          case note: Note => NetworkNode.noteNode(note.title, note.content)
+          case tag: Tag => NetworkNode.tagNode(tag.name)
+        }
+        (entity, networkNode)
+      })
       .toMap
-    nodes = idxByNode.map { case (entity, idx) =>
-      entity match {
-        case note: Note => NetworkNode.noteNode(idx, note.title, note.content)
-        case tag: Tag => NetworkNode.tagNode(idx, tag.name)
-      }
-    }
     edges = neighborhood
       .flatMap(_.edges)
       .filter(edge => {
-        idxByNode.get(edge.source.toOuter).isDefined &&
-        idxByNode.get(edge.target.toOuter).isDefined
+        nodeMap.get(edge.source).isDefined &&
+        nodeMap.get(edge.target).isDefined
       })
       // De-dupe edges
       .groupBy(edge => {
-        val source = idxByNode(edge.source.toOuter)
-        val target = idxByNode(edge.target.toOuter)
+        val source = nodeMap(edge.source).id
+        val target = nodeMap(edge.target).id
         (Math.min(source, target), Math.max(source, target))
       })
       .map { case ((source, target), edges) =>
@@ -56,5 +58,5 @@ class MemoryMindmap[F[_]: MonadError[*[_], Throwable]](
           NetworkEdge(source, target, arrows = Some("to,from"))
         }
       }
-  } yield (Network(nodes = nodes, edges = edges))
+  } yield (Network(nodes = nodeMap.values, edges = edges))
 }

--- a/src/main/scala/mindmap/effect/controller/NetworkController.scala
+++ b/src/main/scala/mindmap/effect/controller/NetworkController.scala
@@ -26,6 +26,7 @@ class NetworkController[F[_]: MonadError[*[_], Throwable]: Defer[
   mindmap: MindmapAlgebra[F],
   zettel: ZettelkastenAlgebra[F]
 ) extends Http4sDsl[F] {
+  private implicit val formats = Serialization.formats(NoTypeHints)
   private implicit val log: Logging[F] =
     Logging.Make[F].forService[NetworkController[F]]
 
@@ -61,19 +62,13 @@ class NetworkController[F[_]: MonadError[*[_], Throwable]: Defer[
         error"Error: ${e.getMessage()}"
       }
     sub <- mindmap.subnetwork(tag)
-    resp <- {
-      implicit val formats = Serialization.formats(NoTypeHints)
-      Ok(Serialization.write(sub))
-    }
+    resp <- Ok(Serialization.write(sub))
   } yield (resp)
 
   private def find(id: Long): F[Response[F]] = for {
     nodeOpt <- mindmap.find(id)
     resp <- nodeOpt match {
-      case Some(node) => {
-        implicit val formats = Serialization.formats(NoTypeHints)
-        Ok(Serialization.write(node))
-      }
+      case Some(node) => Ok(Serialization.write(node))
       case None => NotFound()
     }
   } yield (resp)

--- a/src/main/scala/mindmap/effect/controller/TagsController.scala
+++ b/src/main/scala/mindmap/effect/controller/TagsController.scala
@@ -10,6 +10,8 @@ import org.http4s.Header
 import org.http4s.HttpRoutes
 import org.http4s.Response
 import org.http4s.dsl.Http4sDsl
+import org.json4s.NoTypeHints
+import org.json4s.native.Serialization
 import tofu.logging.Logging
 import tofu.syntax.logging._
 
@@ -22,6 +24,7 @@ class TagsController[
 ](
   zettel: ZettelkastenAlgebra[F]
 ) extends Http4sDsl[F] {
+  private implicit val formats = Serialization.formats(NoTypeHints)
   private implicit val log: Logging[F] =
     Logging.Make[F].forService[TagsController[F]]
 
@@ -40,7 +43,26 @@ class TagsController[
     resp <- Ok(template.body, Header("Content-Type", "text/html"))
   } yield (resp)
 
-  def routes(): HttpRoutes[F] = HttpRoutes.of[F] { case GET -> Root / name =>
-    tag(name)
+  private def index(): F[Response[F]] = for {
+    tags <- zettel.tags()
+    resp <- Ok(Serialization.write(tags))
+  } yield (resp)
+
+  private def find(id: Long): F[Response[F]] = for {
+    tagOpt <- zettel.findTag(id)
+    tag <- MonadError[F, Throwable]
+      .fromOption(
+        tagOpt,
+        new Exception(f"Cannot find tag with id: $id")
+      )
+    notes <- zettel.getTagNotes(tag)
+    template = html.tag(tag.name, notes)
+    resp <- Ok(template.body, Header("Content-Type", "text/html"))
+  } yield (resp)
+
+  def routes(): HttpRoutes[F] = HttpRoutes.of[F] {
+    case GET -> Root => index()
+    case GET -> Root / name => tag(name)
+    case GET -> Root / "find" / LongVar(id) => find(id)
   }
 }

--- a/src/main/scala/mindmap/effect/zettlekasten/MemoryZettlekastenRepository.scala
+++ b/src/main/scala/mindmap/effect/zettlekasten/MemoryZettlekastenRepository.scala
@@ -11,11 +11,11 @@ import mindmap.model.Tag
 import mindmap.model.Zettelkasten
 import mindmap.model.ZettelkastenAlgebra
 
-class MemoryZettelkastenRepository[F[_]: Monad[*[_]]](
+class MemoryZettelkastenRepository[F[+_]: Monad[*[_]]](
   zettelkasten: Zettelkasten
 ) extends ZettelkastenAlgebra[F] {
-  def getNote(name: String): F[Option[Note]] =
-    zettelkasten.notes.find(_.title == name).pure[F]
+  def getNote(title: String): F[Option[Note]] =
+    zettelkasten.notes.find(_.title == title).pure[F]
 
   def getTag(name: String): F[Option[Tag]] =
     zettelkasten.tags.find(_.name == name).pure[F]
@@ -41,4 +41,12 @@ class MemoryZettelkastenRepository[F[_]: Monad[*[_]]](
         .toSet
         .pure[F]
     } yield (notes)
+
+  def notes(): F[Iterable[Note]] = zettelkasten.notes.pure[F]
+
+  def tags(): F[Set[Tag]] = zettelkasten.tags.toSet.pure[F]
+
+  def findNote(id: Long): F[Option[Note]] = zettelkasten.findNote(id).pure[F]
+
+  def findTag(id: Long): F[Option[Tag]] = zettelkasten.findTag(id).pure[F]
 }

--- a/src/main/scala/mindmap/model/MindmapAlgebra.scala
+++ b/src/main/scala/mindmap/model/MindmapAlgebra.scala
@@ -7,4 +7,6 @@ trait MindmapAlgebra[F[_]] {
   def network(): F[Network]
 
   def subnetwork(entity: Entity): F[Network]
+
+  def find(id: Long): F[Option[NetworkNode]]
 }

--- a/src/main/scala/mindmap/model/Note.scala
+++ b/src/main/scala/mindmap/model/Note.scala
@@ -4,6 +4,8 @@ import cats.Show
 import cats.Eq
 import java.time.LocalDateTime
 import java.nio.file.Path
+import scala.util.Random
+import scala.math
 
 case class Note(
   content: String,
@@ -11,7 +13,7 @@ case class Note(
   modifiedDate: LocalDateTime,
   title: String,
   path: java.nio.file.Path,
-  id: Option[Long]
+  id: Long
 ) extends Entity
 
 object Note {
@@ -28,7 +30,7 @@ object Note {
       modifiedDate = modifiedDate,
       title = title,
       path = path,
-      id = None
+      id = math.abs(Random.nextLong())
     )
 
   implicit def showForNote: Show[Note] = new Show[Note] {

--- a/src/main/scala/mindmap/model/Tag.scala
+++ b/src/main/scala/mindmap/model/Tag.scala
@@ -1,10 +1,13 @@
 package mindmap.model
 
+import scala.math
+import scala.util.Random
+
 case class Tag(
-  id: Option[Long],
+  id: Long,
   name: String
 ) extends Entity
 
 object Tag {
-  def apply(name: String): Tag = Tag(None, name)
+  def apply(name: String): Tag = Tag(math.abs(Random.nextLong()), name)
 }

--- a/src/main/scala/mindmap/model/Zettelkasten.scala
+++ b/src/main/scala/mindmap/model/Zettelkasten.scala
@@ -8,4 +8,10 @@ case class Zettelkasten(
   notes: List[Note],
   tags: Set[Tag],
   links: List[ResolvedLink]
-)
+) {
+  val noteMap: Map[Long, Note] = notes.map(note => (note.id, note)).toMap
+  val tagMap: Map[Long, Tag] = tags.map(tag => (tag.id, tag)).toMap
+
+  def findNote(id: Long): Option[Note] = noteMap.get(id)
+  def findTag(id: Long): Option[Tag] = tagMap.get(id)
+}

--- a/src/main/scala/mindmap/model/ZettlekastenAlgebra.scala
+++ b/src/main/scala/mindmap/model/ZettlekastenAlgebra.scala
@@ -6,4 +6,12 @@ trait ZettelkastenAlgebra[F[_]] {
   def getTag(name: String): F[Option[Tag]]
 
   def getTagNotes(tag: Tag): F[Set[Note]]
+
+  def notes(): F[Iterable[Note]]
+
+  def tags(): F[Set[Tag]]
+
+  def findNote(id: Long): F[Option[Note]]
+
+  def findTag(id: Long): F[Option[Tag]]
 }

--- a/src/main/scala/mindmap/model/graph/Network.scala
+++ b/src/main/scala/mindmap/model/graph/Network.scala
@@ -3,4 +3,8 @@ package mindmap.model.graph
 case class Network(
   nodes: Iterable[NetworkNode],
   edges: Iterable[NetworkEdge]
-)
+) {
+  val nodeMap: Map[Long, NetworkNode] = nodes.map(node => (node.id, node)).toMap
+
+  def find(id: Long): Option[NetworkNode] = nodeMap.get(id)
+}

--- a/src/main/scala/mindmap/model/graph/NetworkNode.scala
+++ b/src/main/scala/mindmap/model/graph/NetworkNode.scala
@@ -1,6 +1,8 @@
 package mindmap.model.graph
 
+import scala.math.abs
 import scala.math.sqrt
+import scala.util.Random
 
 import mindmap.model.Note
 import mindmap.model.Tag
@@ -14,7 +16,8 @@ case class NetworkNode(
   group: Option[String] = None,
   physics: Option[Boolean] = None,
   hidden: Option[Boolean] = None,
-  mass: Option[Double] = None
+  x: Option[Long] = None,
+  y: Option[Long] = None
 )
 
 object NetworkNode {
@@ -31,25 +34,16 @@ object NetworkNode {
   def toggle(node: NetworkNode, show: Boolean): NetworkNode =
     if (show) shown(node) else hidden(node)
 
-  def noteNode(idx: Long, label: String, content: String): NetworkNode =
+  def noteNode(label: String, content: String): NetworkNode =
     NetworkNode(
-      idx,
+      abs(Random.nextLong()),
       label,
       group = Some("note")
     )
 
-  def tagNode(idx: Long, label: String): NetworkNode = NetworkNode(
-    idx,
+  def tagNode(label: String): NetworkNode = NetworkNode(
+    abs(Random.nextLong()),
     label,
     group = Some("tag")
   )
-
-  def clusterNode(idx: Long, tag: Tag, clustered: Seq[Note]): NetworkNode = {
-    NetworkNode(
-      idx,
-      tag.name,
-      group = Some("cluster"),
-      mass = Some(sqrt(clustered.size + 1))
-    )
-  }
 }

--- a/src/main/scala/mindmap/model/graph/NetworkNode.scala
+++ b/src/main/scala/mindmap/model/graph/NetworkNode.scala
@@ -1,7 +1,6 @@
 package mindmap.model.graph
 
-import scala.math.abs
-import scala.math.sqrt
+import scala.math
 import scala.util.Random
 
 import mindmap.model.Note
@@ -15,9 +14,7 @@ case class NetworkNode(
   title: Option[String] = None,
   group: Option[String] = None,
   physics: Option[Boolean] = None,
-  hidden: Option[Boolean] = None,
-  x: Option[Long] = None,
-  y: Option[Long] = None
+  hidden: Option[Boolean] = None
 )
 
 object NetworkNode {
@@ -36,14 +33,14 @@ object NetworkNode {
 
   def noteNode(label: String, content: String): NetworkNode =
     NetworkNode(
-      abs(Random.nextLong()),
-      label,
+      id = math.abs(Random.nextLong()),
+      label = label,
       group = Some("note")
     )
 
   def tagNode(label: String): NetworkNode = NetworkNode(
-    abs(Random.nextLong()),
-    label,
+    id = math.abs(Random.nextLong()),
+    label = label,
     group = Some("tag")
   )
 }

--- a/src/test/scala/mindmap/model/parser/markdown/BlockParsersSpec.scala
+++ b/src/test/scala/mindmap/model/parser/markdown/BlockParsersSpec.scala
@@ -31,22 +31,50 @@ class BlockParsersSpec extends AnyFunSpec {
 
     it("should parse all tags") {
       val result = parsers.parse(parser, tagLine)
-      assertParsed(result, tags)
+      assertParsed(
+        result,
+        (block: TagBlock) => {
+          block.tags.zip(tags.tags).forall { case (a, b) =>
+            a.name == b.name
+          }
+        }
+      )
     }
 
     it("should allow tags with spaces") {
       val result = parsers.parse(parser, tagLineWithSpaces)
-      assertParsed(result, tagsWithSpaces)
+      assertParsed(
+        result,
+        (block: TagBlock) => {
+          block.tags.zip(tags.tags).forall { case (a, b) =>
+            a.name == b.name
+          }
+        }
+      )
     }
 
     it("should allow preceding indentation up to 3") {
       val result = parsers.parse(parser, f"   ${tagLine}")
-      assertParsed(result, tags)
+      assertParsed(
+        result,
+        (block: TagBlock) => {
+          block.tags.zip(tags.tags).forall { case (a, b) =>
+            a.name == b.name
+          }
+        }
+      )
     }
 
     it("should strip trailing whitespace") {
       val result = parsers.parse(parser, f"${tagLine}  \t  ")
-      assertParsed(result, tags)
+      assertParsed(
+        result,
+        (block: TagBlock) => {
+          block.tags.zip(tags.tags).forall { case (a, b) =>
+            a.name == b.name
+          }
+        }
+      )
     }
   }
 


### PR DESCRIPTION
Instead of generating them via node index
Enable querying node by ID

Generate for `Note`, `Tag`, and `NetworkNode`